### PR TITLE
feat: add the date to the exception for ECB provider

### DIFF
--- a/src/Provider/EuropeanCentralBankProvider.php
+++ b/src/Provider/EuropeanCentralBankProvider.php
@@ -104,7 +104,7 @@ final class EuropeanCentralBankProvider implements ExchangeRateProviderInterface
             return $this->exchangeRateFactory->create($sourceCurrency, $targetCurrency, $rates[$dateString][$targetCurrency->getCode()]);
         }
 
-        throw new ExchangeRateNotFoundException($sourceCurrency, $targetCurrency);
+        throw new ExchangeRateNotFoundException($sourceCurrency, $targetCurrency, sprintf('Unable to find exchange rate for %s to %s for the date `%s`.', $sourceCurrency->getCode(), $targetCurrency->getName(), $dateString));
     }
 
 


### PR DESCRIPTION
It permits to know the date because the exception can be throwed if there is no rate for the date.